### PR TITLE
Lint and Unit tests workflows

### DIFF
--- a/.github/workflows/lint-unit.yaml
+++ b/.github/workflows/lint-unit.yaml
@@ -1,0 +1,34 @@
+name: Linting and Unit Tests
+
+on:
+  push:
+    branches:
+      - ci
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches: [ main ]
+
+jobs:
+  lint-unit:
+    name: Lint and Unit tests
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.6", "3.8", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+    - name: Run lint checkers
+      run: tox -e lint
+    - name: Run unit tests
+      run: tox -e unit

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,30 @@
+name: SonarCloud
+
+on:
+  push:
+    branches:
+      - ci
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install tox and any other packages
+        run: pip install tox
+      - name: Run tox
+        run: make unittest
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This change adds only Unit tests and Linting to CI. I don't think it's worth spending effort designing workflow for functional tests that would build its own local snap when the exporter snap will be released shortly to snapstore.