### PR TITLE
Allow mac address detection overrides in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 *.charm
 .tox/
 .coverage
+coverage.xml
 __pycache__/
 *.py[cod]
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,41 @@
-venv/
-build/
-*.charm
-.tox/
-.coverage
-coverage.xml
+# Juju files
+.unit-state.db
+
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
-.idea
-.vscode/
+*$py.class
+
+# Tests files and dir
+.pytest_cache/
+.coverage
+.tox
+.venv
+reports/
+htmlcov/
 .mypy_cache
+
+# Log files
+*.log
+
+# IDEs
+.idea/
+.vscode/
+
+# vi
+.*.swp
+
+# version data
+repo-info
+
+# Python builds
+deb_dist/
+dist/
+
+# Snaps
+*.snap
+
+# Builds
+.build/
+build/
+*.charm

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+.mypy_cache

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ unittests:
 	@echo "Running unit tests"
 	@tox -e unit -- ${UNIT_ARGS}
 
-functional: 
+functional: build
 	@echo "Executing functional tests using built charm at ${PROJECTPATH}"
 	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
 

--- a/config.yaml
+++ b/config.yaml
@@ -55,7 +55,7 @@ options:
     description: |
       The list of MAC address prefixes to be considered as virtual machines.
       The default value contains some of the most common MAC prefixes seen in
-      virtual environment.
+      virtual environment (QEMU, Microsoft, and VMWare).
       This configuration accepts comma-separated MAC prefixes in string format.
     default: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56"
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -51,3 +51,11 @@ options:
       How long should Prometheus wait for response to scrape request before timing out (In seconds)
     default: 30
     type: int
+  virtual-macs:
+    description: |
+      The list of MAC address prefixes to be considered as virtual machines.
+      The default value contains some of the most common MAC prefixes seen in
+      virtual environment.
+      This configuration accepts comma-separated MAC prefixes in string format.
+    default: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56,fa:16:3e"
+    type: string

--- a/config.yaml
+++ b/config.yaml
@@ -57,5 +57,5 @@ options:
       The default value contains some of the most common MAC prefixes seen in
       virtual environment.
       This configuration accepts comma-separated MAC prefixes in string format.
-    default: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56,fa:16:3e"
+    default: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56"
     type: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip_glob = [
 ]
 
 [tool.pylint]
-max-line-length = 120
+max-line-length = 99
 
 [tool.mypy]
 warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ skip_glob = [
   "report"
 ]
 
+[tool.pylint]
+max-line-length = 120
+
 [tool.mypy]
 warn_unused_ignores = true
 warn_unused_configs = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,7 +17,7 @@ import os
 import pathlib
 from base64 import b64decode
 from binascii import Error as Base64Error
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import yaml
 from charmhelpers.core import hookenv
@@ -116,7 +116,7 @@ class PrometheusJujuExporterCharm(CharmBase):
 
         return ca_cert
 
-    def generate_exporter_config(self) -> Dict[str, Dict[str, Optional[str]]]:
+    def generate_exporter_config(self) -> Dict[str, Dict[str, Union[List[str], str, None]]]:
         """Generate exporter service config based on the values from charm config."""
         config = ExporterConfig(
             customer=self.config.get("customer"),
@@ -127,7 +127,7 @@ class PrometheusJujuExporterCharm(CharmBase):
             password=self.config.get("juju-password"),
             interval=self.config.get("scrape-interval"),
             port=self.config.get("scrape-port"),
-            prefixes=self.config.get("virtual-macs").split(","),
+            prefixes=self.config.get("virtual-macs"),
         )
 
         return config.render()

--- a/src/charm.py
+++ b/src/charm.py
@@ -49,7 +49,7 @@ class PrometheusJujuExporterCharm(CharmBase):
         "juju-password": "juju.password",
         "scrape-interval": "exporter.collect_interval",
         "scrape-port": "exporter.port",
-        "virtual-macs": "machine.virt_macs",
+        "virtual-macs": "detection.virt_macs",
     }
 
     def __init__(self, *args: Any) -> None:
@@ -127,7 +127,7 @@ class PrometheusJujuExporterCharm(CharmBase):
             password=self.config.get("juju-password"),
             interval=self.config.get("scrape-interval"),
             port=self.config.get("scrape-port"),
-            prefixes=self.config.get("virtual-macs"),
+            prefixes=self.config.get("virtual-macs").split(","),
         )
 
         return config.render()

--- a/src/charm.py
+++ b/src/charm.py
@@ -49,6 +49,7 @@ class PrometheusJujuExporterCharm(CharmBase):
         "juju-password": "juju.password",
         "scrape-interval": "exporter.collect_interval",
         "scrape-port": "exporter.port",
+        "virtual-macs": "machine.virt_macs",
     }
 
     def __init__(self, *args: Any) -> None:
@@ -126,6 +127,7 @@ class PrometheusJujuExporterCharm(CharmBase):
             password=self.config.get("juju-password"),
             interval=self.config.get("scrape-interval"),
             port=self.config.get("scrape-port"),
+            prefixes=self.config.get("virtual-macs"),
         )
 
         return config.render()

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -33,6 +33,7 @@ class ExporterConfig(NamedTuple):
     password: Optional[str] = None
     interval: Optional[str] = None
     port: Optional[str] = None
+    prefixes: Optional[str] = None
 
     def render(self) -> Dict[str, Dict[str, Optional[str]]]:
         """Return dict that can be written to an exporter config file as a yaml."""
@@ -50,6 +51,9 @@ class ExporterConfig(NamedTuple):
             "exporter": {
                 "collect_interval": self.interval,
                 "port": self.port,
+            },
+            "machine": {
+                "virt_macs": self.prefixes,
             },
         }
 
@@ -73,6 +77,7 @@ class ExporterSnap:
         "juju.password",
         "exporter.port",
         "exporter.collect_interval",
+        "machine.virt_macs",
     ]
 
     def install(self, snap_path: Optional[str] = None) -> None:

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -33,7 +33,7 @@ class ExporterConfig(NamedTuple):
     password: Optional[str] = None
     interval: Optional[str] = None
     port: Optional[str] = None
-    prefixes: Optional[str] = None
+    prefixes: Optional[list] = None
 
     def render(self) -> Dict[str, Dict[str, Optional[str]]]:
         """Return dict that can be written to an exporter config file as a yaml."""
@@ -52,7 +52,7 @@ class ExporterConfig(NamedTuple):
                 "collect_interval": self.interval,
                 "port": self.port,
             },
-            "machine": {
+            "detection": {
                 "virt_macs": self.prefixes,
             },
         }
@@ -77,7 +77,7 @@ class ExporterSnap:
         "juju.password",
         "exporter.port",
         "exporter.collect_interval",
-        "machine.virt_macs",
+        "detection.virt_macs",
     ]
 
     def install(self, snap_path: Optional[str] = None) -> None:

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -9,7 +9,7 @@ Module focused on handling operations related to prometheus-juju-exporter snap.
 import logging
 import os
 import subprocess
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 import yaml
 from charmhelpers.fetch import snap
@@ -33,9 +33,9 @@ class ExporterConfig(NamedTuple):
     password: Optional[str] = None
     interval: Optional[str] = None
     port: Optional[str] = None
-    prefixes: Optional[list] = None
+    prefixes: Optional[str] = None
 
-    def render(self) -> Dict[str, Dict[str, Optional[str]]]:
+    def render(self) -> Dict[str, Dict[str, Union[List[str], str, None]]]:
         """Return dict that can be written to an exporter config file as a yaml."""
         return {
             "customer": {
@@ -53,7 +53,7 @@ class ExporterConfig(NamedTuple):
                 "port": self.port,
             },
             "detection": {
-                "virt_macs": self.prefixes,
+                "virt_macs": self.prefixes.split(",") if self.prefixes else self.prefixes,
             },
         }
 

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+python-openstackclient

--- a/tests/integration/tests/configure_charm.py
+++ b/tests/integration/tests/configure_charm.py
@@ -63,10 +63,11 @@ def setup_juju_credentials() -> None:
             "customer": "Test org",
             "cloud-name": "Test Cloud",
             "controller-url": endpoint,
-            "controller-ca": b64encode(ca_cert.encode()).decode(encoding="ascii"),
+            "controller-ca-cert": b64encode(ca_cert.encode()).decode(encoding="ascii"),
             "juju-user": username,
             "juju-password": password,
             "scrape-interval": "1",
+            "virtual-macs": "BAD:BAD:BAD,FFF:FFF:FFF",
         },
     )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -122,6 +122,7 @@ def test_generate_exporter_config_complete(harness, mocker):
     user = "foo"
     password = "bar"
     interval = 5
+    prefixes = "TTT:TTT:TTT,FFF:FFF:FFF"
     mocker.patch.object(harness.charm, "get_controller_ca_cert", return_value=ca_cert)
 
     expected_snap_config = {
@@ -139,6 +140,9 @@ def test_generate_exporter_config_complete(harness, mocker):
             "username": user,
             "controller_cacert": ca_cert,
         },
+        "machine": {
+            "virt_macs": prefixes,
+        },
     }
 
     with harness.hooks_disabled():
@@ -151,6 +155,7 @@ def test_generate_exporter_config_complete(harness, mocker):
                 "juju-password": password,
                 "scrape-interval": interval,
                 "scrape-port": port,
+                "virtual-macs": prefixes,
             }
         )
 
@@ -173,6 +178,7 @@ def test_generate_exporter_config_incomplete(harness, mocker):
                 "juju-password": "",
                 "scrape-interval": 5,
                 "scrape-port": 5000,
+                "virtual-macs": "FFF:FFF:FFF"
             }
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -140,8 +140,8 @@ def test_generate_exporter_config_complete(harness, mocker):
             "username": user,
             "controller_cacert": ca_cert,
         },
-        "machine": {
-            "virt_macs": prefixes,
+        "detection": {
+            "virt_macs": prefixes.split(","),
         },
     }
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -178,7 +178,7 @@ def test_generate_exporter_config_incomplete(harness, mocker):
                 "juju-password": "",
                 "scrape-interval": 5,
                 "scrape-port": 5000,
-                "virtual-macs": "FFF:FFF:FFF"
+                "virtual-macs": "FFF:FFF:FFF",
             }
         )
 

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -91,7 +91,7 @@ def test_validate_config():
             "username": "foo",
             "password": "bar",
         },
-        "machine": {
+        "detection": {
             "virt_macs": "FFF:FFF:FFF",
         },
     }

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -91,6 +91,9 @@ def test_validate_config():
             "username": "foo",
             "password": "bar",
         },
+        "machine": {
+            "virt_macs": "FFF:FFF:FFF",
+        },
     }
 
     exporter_ = exporter.ExporterSnap()
@@ -174,7 +177,7 @@ def test_execute_service_action(mocker):
     mock_call.assert_called_once_with(expected_command)
 
 
-def test_execute_service_action_unknownw(mocker):
+def test_execute_service_action_unknown(mocker):
     """Test that '_execute_service_action' raises error if it does not recognize the action."""
     mock_call = mocker.patch.object(exporter.subprocess, "call")
     bad_action = "foo"

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -14,10 +14,8 @@ import exporter
 def validate_config_error(config: Dict, expected_error: str):
     """Run config validation and verify that expected error is present in the raised exception."""
     exporter_ = exporter.ExporterSnap()
-    with pytest.raises(exporter.ExporterConfigError) as exc:
+    with pytest.raises(exporter.ExporterConfigError, match=expected_error):
         exporter_.validate_config(config)
-
-    assert expected_error in str(exc)
 
 
 @pytest.mark.parametrize("local_snap", [True, False])

--- a/tox.ini
+++ b/tox.ini
@@ -90,4 +90,4 @@ deps =
     -r {toxinidir}/tests/integration/requirements.txt
 changedir = {toxinidir}/tests/integration
 commands =
-    functest-run-suite  --bundle {posargs}
+    functest-run-suite --keep-faulty-model --bundle {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -82,12 +82,4 @@ deps =
     -r {toxinidir}/tests/integration/requirements.txt
 changedir = {toxinidir}/tests/integration
 commands =
-    functest-run-suite {posargs}
-
-[testenv:func-target]
-basepython = python3
-deps =
-    -r {toxinidir}/tests/integration/requirements.txt
-changedir = {toxinidir}/tests/integration
-commands =
-    functest-run-suite --keep-faulty-model --bundle {posargs}
+    functest-run-suite {posargs:--keep-faulty-model}


### PR DESCRIPTION
This PR complements https://github.com/canonical/prometheus-juju-exporter/pull/19. It adds a new config option for the collection of virtual MAC prefixes, which enables overriding in non-standard virtual environment. It also fixes some errors in function tests