### PR TITLE
Implement service status checking.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -51,9 +51,11 @@ def evaluate_status(func: Callable) -> Callable:
         """Execute wrapped method and perform status assessment."""
         result = func(self, *args, **kwargs)
 
-        exporter_running = self.exporter.running()
+        exporter_running = self.exporter.is_running()
         if isinstance(self.unit.status, ActiveStatus) and not exporter_running:
-            self.unit.status = BlockedStatus("Exporter service is inactive.")
+            self.unit.status = BlockedStatus(
+                "Exporter service is inactive. (See service logs in unit.)"
+            )
         elif not isinstance(self.unit.status, ActiveStatus) and exporter_running:
             self.unit.status = ActiveStatus("Unit is ready")
 
@@ -224,7 +226,7 @@ class PrometheusJujuExporterCharm(CharmBase):
 
     @evaluate_status
     def _on_update_status(self, _: UpdateStatusEvent) -> None:
-        """Asses unit's status."""
+        """Assess unit's status."""
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -189,7 +189,7 @@ class ExporterSnap:
         """Start exporter service."""
         self._execute_service_action("start")
 
-    def running(self) -> bool:
+    def is_running(self) -> bool:
         """Check if exporter service is running."""
         return ch_host.service_running(self.service_name)
 

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -12,6 +12,7 @@ import subprocess
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 import yaml
+from charmhelpers.core import host as ch_host
 from charmhelpers.fetch import snap
 
 # Log messages can be retrieved using juju debug-log
@@ -79,6 +80,11 @@ class ExporterSnap:
         "exporter.collect_interval",
         "detection.virt_macs",
     ]
+
+    @property
+    def service_name(self) -> str:
+        """Return name of the exporter's systemd service."""
+        return f"snap.{self.SNAP_NAME}.{self.SNAP_NAME}.service"
 
     def install(self, snap_path: Optional[str] = None) -> None:
         """Install prometheus-juju-exporter snap.
@@ -182,6 +188,10 @@ class ExporterSnap:
     def start(self) -> None:
         """Start exporter service."""
         self._execute_service_action("start")
+
+    def running(self) -> bool:
+        """Check if exporter service is running."""
+        return ch_host.service_running(self.service_name)
 
     def _execute_service_action(self, action: str) -> None:
         """Execute one of the supported snap service actions.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -290,7 +290,7 @@ def test_on_config_changed_success(mocker, harness):
     """Test successful application of new config values."""
     valid_config = {"valid": "config"}
     mocker.patch.object(harness.charm, "generate_exporter_config", return_value=valid_config)
-    mocker.patch.object(exporter.ExporterSnap, "running", return_value=True)
+    mocker.patch.object(exporter.ExporterSnap, "is_running", return_value=True)
     mock_apply_config = mocker.patch.object(harness.charm.exporter, "apply_config")
     mock_reconfigure_scrape = mocker.patch.object(harness.charm, "reconfigure_scrape_target")
     mock_reconfigure_ports = mocker.patch.object(harness.charm, "reconfigure_open_ports")
@@ -332,7 +332,7 @@ def test_evaluate_status(current_status, service_running, expected_status, harne
     Blocked             Yes                     Active
     Blocked             No                      Blocked
     """
-    mocker.patch.object(exporter.ExporterSnap, "running", return_value=service_running)
+    mocker.patch.object(exporter.ExporterSnap, "is_running", return_value=service_running)
     harness.charm.unit.status = current_status("Initial status")
 
     # trigger actual status evaluation wrapper via update-status event

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,8 +10,10 @@ from unittest import mock
 
 import pytest
 import yaml
+from ops.model import ActiveStatus, BlockedStatus
 
 import charm
+import exporter
 
 
 @pytest.mark.parametrize(
@@ -288,6 +290,7 @@ def test_on_config_changed_success(mocker, harness):
     """Test successful application of new config values."""
     valid_config = {"valid": "config"}
     mocker.patch.object(harness.charm, "generate_exporter_config", return_value=valid_config)
+    mocker.patch.object(exporter.ExporterSnap, "running", return_value=True)
     mock_apply_config = mocker.patch.object(harness.charm.exporter, "apply_config")
     mock_reconfigure_scrape = mocker.patch.object(harness.charm, "reconfigure_scrape_target")
     mock_reconfigure_ports = mocker.patch.object(harness.charm, "reconfigure_open_ports")
@@ -308,3 +311,31 @@ def test_on_prometheus_available(harness, mocker):
     harness.charm._on_prometheus_available(None)
 
     mock_reconfigure.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "current_status, service_running, expected_status",
+    [
+        (ActiveStatus, True, ActiveStatus),
+        (ActiveStatus, False, BlockedStatus),
+        (BlockedStatus, False, BlockedStatus),
+        (BlockedStatus, True, ActiveStatus),
+    ],
+)
+def test_evaluate_status(current_status, service_running, expected_status, harness, mocker):
+    """Test that wrapper that evaluates final unit status sets correct workload status.
+
+    Expected behavior:
+    <Current Status>  <Is exporter running>  <Final Status>
+    Active              Yes                     Active
+    Active              No                      Blocked
+    Blocked             Yes                     Active
+    Blocked             No                      Blocked
+    """
+    mocker.patch.object(exporter.ExporterSnap, "running", return_value=service_running)
+    harness.charm.unit.status = current_status("Initial status")
+
+    # trigger actual status evaluation wrapper via update-status event
+    harness.charm._on_update_status(None)
+
+    assert isinstance(harness.charm.unit.status, expected_status)

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -185,3 +185,21 @@ def test_execute_service_action_unknown(mocker):
         exporter_._execute_service_action(bad_action)
 
     mock_call.assert_not_called()
+
+
+def test_service_name():
+    """Test that `service_name` property returns expected value."""
+    exporter_ = exporter.ExporterSnap()
+    expected_service = f"snap.{exporter_.SNAP_NAME}.{exporter_.SNAP_NAME}.service"
+
+    assert exporter_.service_name == expected_service
+
+
+@pytest.mark.parametrize("running", [True, False])
+def test_exporter_service_running(running, mocker):
+    """Test that `running` method returns True/False based on if service is running."""
+    mocker.patch.object(exporter.ch_host, "service_running", return_value=running)
+
+    exporter_ = exporter.ExporterSnap()
+
+    assert exporter_.running() == running

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -197,9 +197,12 @@ def test_service_name():
 
 @pytest.mark.parametrize("running", [True, False])
 def test_exporter_service_running(running, mocker):
-    """Test that `running` method returns True/False based on if service is running."""
-    mocker.patch.object(exporter.ch_host, "service_running", return_value=running)
+    """Test that `is_running` method returns True/False based on service status."""
+    mock_service_running = mocker.patch.object(
+        exporter.ch_host, "service_running", return_value=running
+    )
 
     exporter_ = exporter.ExporterSnap()
 
-    assert exporter_.running() == running
+    assert exporter_.is_running() == running
+    mock_service_running.assert_called_once_with(exporter_.service_name)


### PR DESCRIPTION
If exporter service is not running. Set unit's status to Blocked.

I added a wrapper that can be used as decorator for multiple event handlers so that we can have common spot to evaluate overall unit's status at the end of event handler.