### PR TITLE
Add alert rule for juju machines being down

### DIFF
--- a/src/prometheus_alert_rules/juju_machines_down.rule
+++ b/src/prometheus_alert_rules/juju_machines_down.rule
@@ -1,8 +1,7 @@
 alert: JujuMachineAgentsDown
-expr: max(sum by (instance) (juju_machine_state{juju_application=~".*",juju_charm=~".*",juju_model=~".*",juju_model_uuid=~".*"} offset 1h)) - max(sum by (instance) (juju_machine_state{juju_application=~".*",juju_charm=~".*",juju_model=~".*",juju_model_uuid=~".*"})) > 0
-for: 15m
+expr: max(count by (instance) (juju_machine_state{juju_application=~".*",juju_charm=~".*",juju_model=~".*",juju_model_uuid=~".*"} == 0)) > 0
+for: 10m
 labels:
   severity: warning
 annotations:
-  summary: "One or more juju machine agents are down."
-  description: "The juju machines count has decreased compared to 1h ago."
+  summary: "One or more juju machine agents are down for more than 10m."

--- a/src/prometheus_alert_rules/juju_machines_down.rule
+++ b/src/prometheus_alert_rules/juju_machines_down.rule
@@ -1,0 +1,8 @@
+alert: JujuMachineAgentsDown
+expr: max(sum by (instance) (juju_machine_state{juju_application=~".*",juju_charm=~".*",juju_model=~".*",juju_model_uuid=~".*"} offset 1h)) - max(sum by (instance) (juju_machine_state{juju_application=~".*",juju_charm=~".*",juju_model=~".*",juju_model_uuid=~".*"})) > 0
+for: 15m
+labels:
+  severity: warning
+annotations:
+  summary: "One or more juju machine agents are down."
+  description: "The juju machines count has decreased compared to 1h ago."


### PR DESCRIPTION
Alert when the number of machines has decreased compared to 1h ago. The alert will start firing only if the condition holds continuously for 15 minutes. This is to avoid alerts when some machines are flapping(eg. go down and come up within a few minutes).
This alert can be tested by removing one or more juju machines. The alert will start firing after 15 minutes. 