### PR TITLE
Revert name of the relation with prometheus2 charm.

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,9 +34,9 @@ resources:
     filename: prometheus-juju-exporter.snap
 
 provides:
-  prometheus-legacy-scrape:
+  prometheus-scrape:  # Relation with legacy "prometheus2" charm
     interface: prometheus
-  prometheus-k8s-scrape:
+  prometheus-k8s-scrape:  # Relation with new "prometheus-k8s" charm
     interface: prometheus_scrape
   grafana-k8s-dashboard:
     interface: grafana_dashboard

--- a/src/charm.py
+++ b/src/charm.py
@@ -85,7 +85,7 @@ class PrometheusJujuExporterCharm(CharmBase):
         """Initialize charm."""
         super().__init__(*args)
         self.exporter = ExporterSnap()
-        self.prometheus_target = PrometheusScrapeTarget(self, "prometheus-legacy-scrape")
+        self.prometheus_target = PrometheusScrapeTarget(self, "prometheus-scrape")
         self._snap_path: Optional[str] = None
         self._snap_path_set = False
 
@@ -181,7 +181,7 @@ class PrometheusJujuExporterCharm(CharmBase):
         """Update scrape target configuration in related Prometheus application.
 
         Note: this function has no effect if there's no application related via
-        'prometheus-legacy-scrape'.
+        'prometheus-scrape'.
         """
         port = self.config["scrape-port"]
         interval_minutes = self.config["scrape-interval"]


### PR DESCRIPTION
We previously renamed relation with `prometheus2` charm to `prometheus-legacy-scrape` not realizing that this will cause major problems when upgrading already existing deployments.

This change renames the relation back to `prometheus-scrape` which I think is OK. New naming would be:

- `prometheus-scrape` - relation with `prometheus2` charm
- `prometheus-k8s-scrape` - relation with `prometheus-k8s` charm