### PR TITLE
Add handling for `charm-upgrade` and `stop` events.

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -103,6 +103,10 @@ class ExporterSnap:
             logger.info("Installing %s snap from snap store.", self.SNAP_NAME)
             snap.snap_install(self.SNAP_NAME)
 
+    def uninstall(self) -> None:
+        """Remove prometheus-juju-exporter snap."""
+        snap.snap_remove(self.SNAP_NAME)
+
     def _validate_required_options(self, config: Dict[str, Any]) -> List[str]:
         """Validate that config has all required options for snap to run."""
         missing_options = []

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -34,6 +34,16 @@ def test_exporter_snap_install(local_snap, mocker):
         mock_snap_install.assert_called_once_with(exporter_.SNAP_NAME)
 
 
+def test_exporter_snap_uninstall(mocker):
+    """Test uninstallation of exporter snap."""
+    snap_remove_mock = mocker.patch.object(exporter.snap, "snap_remove")
+
+    exporter_ = exporter.ExporterSnap()
+    exporter_.uninstall()
+
+    snap_remove_mock.assert_called_once_with(exporter_.SNAP_NAME)
+
+
 def test_validate_config_missing_fields():
     """Test config validation with all required fields missing."""
     missing_options = ", ".join(exporter.ExporterSnap._REQUIRED_CONFIG)


### PR DESCRIPTION
We were lacking handlers for these two lifecycle events.

- on `charm-upgrade` triggers re-installation of snap and re-renders the config. (This is important because this event is triggered when new resource (snap) is attached.
- on `stop` triggers removal of exporter snap