### PR TITLE
Pin ops version to support bionic deployments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 charmhelpers
-ops >= 1.5.0
+
+# pin ops framework version to
+# support bionic deployments
+ops >= 1.5.0,< 2.0.0

--- a/tests/functional/tests/bundles/bionic.yaml
+++ b/tests/functional/tests/bundles/bionic.yaml
@@ -1,0 +1,1 @@
+base.yaml

--- a/tests/functional/tests/bundles/overlays/bionic.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/bionic.yaml.j2
@@ -1,0 +1,2 @@
+series: bionic
+

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -3,6 +3,7 @@ charm_name: prometheus-juju-exporter
 gate_bundles:
   - jammy
   - focal
+  - bionic
 
 tests:
   - tests.test_charm.BasicPrometheusJujuExporterTests


### PR DESCRIPTION
Ops 2 has dropped support for Python 3.7 and downwards, which prevents the charm to be deployed on bionic machines (where python 3.6 is the default). This PR pins the ops version to <2.0 to workaround the issue.