### PR TITLE
Add ability to use only selected interfaces for machine type detection.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -59,3 +59,12 @@ options:
       This configuration accepts comma-separated MAC prefixes in string format.
     default: "52:54:00,fa:16:3e,06:f1:3a,00:0d:3a,00:50:56"
     type: string
+  match-interfaces:
+    description: |
+      Interface names that should be considered when detecting machine type. This
+      option takes regular expression that should match "real" interface on the machines.
+      Usage of this option prevents virtual interfaces like 'virbr0' to be detected, and
+      possibly causing machine to be mislabeled as a VM guest.
+      Leaving this option empty will default to matching all interfaces.
+    default: "^(en[os]|eth)\\d+|enp\\d+s\\d+|enx[0-9a-f]+"
+    type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -86,6 +86,7 @@ class PrometheusJujuExporterCharm(CharmBase):
         "scrape-interval": "exporter.collect_interval",
         "scrape-port": "exporter.port",
         "virtual-macs": "detection.virt_macs",
+        "match-interfaces": "detection.match_interfaces",
     }
 
     def __init__(self, *args: Any) -> None:
@@ -182,6 +183,7 @@ class PrometheusJujuExporterCharm(CharmBase):
             interval=self.config.get("scrape-interval"),
             port=self.config.get("scrape-port"),
             prefixes=self.config.get("virtual-macs"),
+            match_interfaces=self.config.get("match-interfaces"),
         )
 
         return config.render()

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -35,6 +35,7 @@ class ExporterConfig(NamedTuple):
     interval: Optional[str] = None
     port: Optional[str] = None
     prefixes: Optional[str] = None
+    match_interfaces: Optional[str] = None
 
     def render(self) -> Dict[str, Dict[str, Union[List[str], str, None]]]:
         """Return dict that can be written to an exporter config file as a yaml."""
@@ -54,7 +55,8 @@ class ExporterConfig(NamedTuple):
                 "port": self.port,
             },
             "detection": {
-                "virt_macs": self.prefixes.split(",") if self.prefixes else self.prefixes,
+                "virt_macs": self.prefixes.split(",") if self.prefixes else [],
+                "match_interfaces": self.match_interfaces or ".*",
             },
         }
 
@@ -79,6 +81,7 @@ class ExporterSnap:
         "exporter.port",
         "exporter.collect_interval",
         "detection.virt_macs",
+        "detection.match_interfaces",
     ]
 
     @property

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -128,6 +128,7 @@ def test_generate_exporter_config_complete(harness, mocker):
     password = "bar"
     interval = 5
     prefixes = "TTT:TTT:TTT,FFF:FFF:FFF"
+    match_interfaces = r"^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+"
     mocker.patch.object(harness.charm, "get_controller_ca_cert", return_value=ca_cert)
 
     expected_snap_config = {
@@ -147,6 +148,7 @@ def test_generate_exporter_config_complete(harness, mocker):
         },
         "detection": {
             "virt_macs": prefixes.split(","),
+            "match_interfaces": match_interfaces,
         },
     }
 
@@ -161,6 +163,7 @@ def test_generate_exporter_config_complete(harness, mocker):
                 "scrape-interval": interval,
                 "scrape-port": port,
                 "virtual-macs": prefixes,
+                "match-interfaces": match_interfaces,
             }
         )
 

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -101,6 +101,7 @@ def test_validate_config():
         },
         "detection": {
             "virt_macs": "FFF:FFF:FFF",
+            "match_interfaces": r"^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+",
         },
     }
 
@@ -216,3 +217,52 @@ def test_exporter_service_running(running, mocker):
 
     assert exporter_.is_running() == running
     mock_service_running.assert_called_once_with(exporter_.service_name)
+
+
+def test_exporter_config_render_defaults():
+    """Test that default values get injected to optional config options."""
+    customer_name = "Test"
+    cloud_name = "Test Cloud"
+    controller_endpoint = "10.0.0.1:17070"
+    ca_cert = "---BEGIN CERT---\ndata\n---END CERT---"
+    username = "admin"
+    password = "pass1"
+    collection_interval = "1"
+    port = "5000"
+
+    default_virt_macs = []
+    default_match_interfaces = r".*"
+
+    expected_config = {
+        "customer": {
+            "name": customer_name,
+            "cloud_name": cloud_name,
+        },
+        "juju": {
+            "controller_endpoint": controller_endpoint,
+            "controller_cacert": ca_cert,
+            "username": username,
+            "password": password,
+        },
+        "exporter": {
+            "collect_interval": collection_interval,
+            "port": port,
+        },
+        "detection": {
+            "virt_macs": default_virt_macs,
+            "match_interfaces": default_match_interfaces,
+        },
+    }
+
+    config = exporter.ExporterConfig(
+        customer=customer_name,
+        cloud=cloud_name,
+        controller=controller_endpoint,
+        ca_cert=ca_cert,
+        user=username,
+        password=password,
+        interval=collection_interval,
+        port=port,
+    )
+
+    assert config.render() == expected_config


### PR DESCRIPTION
This PR uses whitelist approach instead of blacklist to select which interfaces should be used when detecting machine type.

Supersedes #29 