### PR TITLE
Add ability to specify multiple Juju controller endpoints.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,7 +24,11 @@ options:
     default: ""
     type: string
   controller-url:
-    description: Endpoint of a juju controller in format <IP>:<PORT>
+    description: |
+      Endpoint of a juju controller in format <IP>:<PORT>. In case the controller has
+      HA enabled, this option can contain multiple, comma-separated, <IP>:<PORT> values.
+      This is intended only to support HA Juju controller setup, it is not meant to be
+      used for specifying multiple standalone controllers.
     default: ""
     type: string
   controller-ca-cert:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 charmhelpers
-
+packaging
 # pin ops framework version to
 # support bionic deployments
 ops >= 1.5.0,< 2.0.0

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -47,7 +47,7 @@ class ExporterConfig(NamedTuple):
                 "cloud_name": self.cloud,
             },
             "juju": {
-                "controller_endpoint": self.controller,
+                "controller_endpoint": self.controller.split(",") if self.controller else [],
                 "controller_cacert": self.ca_cert,
                 "username": self.user,
                 "password": self.password,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 """Fixture for charm's unit tests."""
+from typing import Dict
 
 import ops.testing
 import pytest
@@ -28,3 +29,13 @@ def harness(unit_hostname, mocker) -> ops.testing.Harness[PrometheusJujuExporter
 
     harness.cleanup()
     ops.testing.SIMULATE_CAN_CONNECT = False
+
+
+@pytest.fixture(scope="session")
+def snap_info_1_0_1() -> Dict:
+    """Sample output of 'snap info' command for exporter snap v1.0.1."""
+    return {
+        "name": "prometheus-juju-exporter",
+        "summary": "collects and exports juju machine status",
+        "installed": "1.0.1            (31) 20MB -",
+    }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -132,6 +132,11 @@ def test_generate_exporter_config_complete(harness, mocker):
     prefixes = "TTT:TTT:TTT,FFF:FFF:FFF"
     match_interfaces = r"^(en[os]|eth)\d+|enp\d+s\d+|enx[0-9a-f]+"
     mocker.patch.object(harness.charm, "get_controller_ca_cert", return_value=ca_cert)
+    mocker.patch.object(
+        exporter.ExporterConfig,
+        "controller_endpoint",
+        mock.PropertyMock(return_value=expected_controller),
+    )
 
     expected_snap_config = {
         "debug": debug,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -121,6 +121,7 @@ def test_generate_exporter_config_complete(harness, mocker):
     """Test generating complete config file for exporter snap."""
     port = 5000
     controller = "juju-controller:17070"
+    expected_controller = [controller]
     customer = "Test Org"
     cloud = "Test cloud"
     ca_cert = "--- CA CERT DATA ---"
@@ -143,7 +144,7 @@ def test_generate_exporter_config_complete(harness, mocker):
             "port": port,
         },
         "juju": {
-            "controller_endpoint": controller,
+            "controller_endpoint": expected_controller,
             "password": password,
             "username": user,
             "controller_cacert": ca_cert,

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -220,11 +220,13 @@ def test_exporter_service_running(running, mocker):
     mock_service_running.assert_called_once_with(exporter_.service_name)
 
 
-def test_exporter_config_render_defaults():
+@pytest.mark.parametrize("controller", ["10.0.0.1:17070", "10.0.0.1:17070,10.0.0.2:17070"])
+def test_exporter_config_render_defaults(controller):
     """Test that default values get injected to optional config options."""
     customer_name = "Test"
     cloud_name = "Test Cloud"
-    controller_endpoint = "10.0.0.1:17070"
+    controller_endpoint = controller
+    expected_controller_endpoint = controller.split(",")
     ca_cert = "---BEGIN CERT---\ndata\n---END CERT---"
     username = "admin"
     password = "pass1"
@@ -241,7 +243,7 @@ def test_exporter_config_render_defaults():
             "cloud_name": cloud_name,
         },
         "juju": {
-            "controller_endpoint": controller_endpoint,
+            "controller_endpoint": expected_controller_endpoint,
             "controller_cacert": ca_cert,
             "username": username,
             "password": password,

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -3,10 +3,13 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 """Unit tests for helper class ExporterSnap that handles actions related to the exporter snap."""
+import subprocess
 from typing import Dict
-from unittest.mock import ANY, mock_open, patch
+from unittest.mock import ANY, PropertyMock, mock_open, patch
 
 import pytest
+import yaml
+from packaging import version
 
 import exporter
 
@@ -220,13 +223,85 @@ def test_exporter_service_running(running, mocker):
     mock_service_running.assert_called_once_with(exporter_.service_name)
 
 
-@pytest.mark.parametrize("controller", ["10.0.0.1:17070", "10.0.0.1:17070,10.0.0.2:17070"])
-def test_exporter_config_render_defaults(controller):
+def test_exporter_snap_version_success(snap_info_1_0_1, mocker):
+    """Test successfully detecting exporter snap version."""
+    expected_version = version.parse("1.0.1")
+    cmd_output = yaml.dump(snap_info_1_0_1)
+    mocker.patch.object(exporter.subprocess, "check_output", return_value=cmd_output)
+
+    assert exporter.ExporterSnap.version() == expected_version
+
+
+def test_exporter_snap_version_not_installed(snap_info_1_0_1, mocker):
+    """Test failure to detect exporter snap version when snap is not installed."""
+    snap_info = snap_info_1_0_1.copy()
+    snap_info.pop("installed")
+    cmd_output = yaml.dump(snap_info)
+    mocker.patch.object(exporter.subprocess, "check_output", return_value=cmd_output)
+
+    with pytest.raises(exporter.ExporterSnapError):
+        _ = exporter.ExporterSnap.version()
+
+
+def test_exporter_snap_version_failure(mocker):
+    """Test failure to get snap info when detecting exporter snap version."""
+    err = subprocess.CalledProcessError(1, "snap info", "Command not found")
+    mocker.patch.object(exporter.subprocess, "check_output", side_effect=err)
+
+    with pytest.raises(exporter.ExporterSnapError):
+        _ = exporter.ExporterSnap.version()
+
+
+@pytest.mark.parametrize(
+    "exporter_version, expected_value",
+    [
+        (version.parse("1.0.1"), "10.0.0.1:17070"),
+        (version.parse("1.0.2"), ["10.0.0.1:17070"]),
+    ],
+)
+def test_exporter_config_controller_endpoint(exporter_version, expected_value, mocker):
+    """Test that ExporterConfig.controller_endpoint returns data in correct format.
+
+    Based on the installed version of snap, this property should return:
+    * single string for prometheus-juju-exporter <= 1.0.1
+    * list of string for prometheus-juju-exporter > 1.0.1
+    """
+    mocker.patch.object(exporter.ExporterSnap, "version", return_value=exporter_version)
+    raw_controller_endpoint = "10.0.0.1:17070"
+    config = exporter.ExporterConfig(controller=raw_controller_endpoint)
+
+    assert config.controller_endpoint == expected_value
+
+
+def test_exporter_config_controller_endpoint_incompatible(mocker):
+    """Test incompatibilities between 'controller_endpoint' value and installed exporter.
+
+    Only prometheus-juju-exporter > 1.0.1 can accept comma-separated list of controller
+    endpoints.
+    """
+    exporter_version = version.parse("1.0.1")
+    mocker.patch.object(exporter.ExporterSnap, "version", return_value=exporter_version)
+    invalid_endpoints = "10.0.0.1:17070,10.0.0.2:17070"
+    config = exporter.ExporterConfig(controller=invalid_endpoints)
+
+    with pytest.raises(exporter.ExporterConfigError):
+        _ = config.controller_endpoint
+
+
+@pytest.mark.parametrize("empty_value", ["", None])
+def test_exporter_config_controller_empty_value(empty_value):
+    """Test that ExporterConfig.controller_endpoint returns expected empty value."""
+    expected_empty_value = ""
+    config = exporter.ExporterConfig(controller=empty_value)
+    assert config.controller_endpoint == expected_empty_value
+
+
+def test_exporter_config_render_defaults(mocker):
     """Test that default values get injected to optional config options."""
     customer_name = "Test"
     cloud_name = "Test Cloud"
-    controller_endpoint = controller
-    expected_controller_endpoint = controller.split(",")
+    controller_endpoint = "10.0.0.1:17070,10.0.0.2:17070"
+    expected_controller_endpoint = controller_endpoint.split(",")
     ca_cert = "---BEGIN CERT---\ndata\n---END CERT---"
     username = "admin"
     password = "pass1"
@@ -237,6 +312,11 @@ def test_exporter_config_render_defaults(controller):
     default_match_interfaces = r".*"
     default_debug = None
 
+    mocker.patch.object(
+        exporter.ExporterConfig,
+        "controller_endpoint",
+        PropertyMock(return_value=expected_controller_endpoint),
+    )
     expected_config = {
         "customer": {
             "name": customer_name,

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands = pre-commit run --all-files
 commands =
     pflake8
     pylint {toxinidir}/src/
-    pylint {toxinidir}/tests/ --disable=E0401,W0212,W0621
+    pylint {toxinidir}/tests/ --disable=E0401,W0212,W0621,R0914
     mypy --install-types --non-interactive {toxinidir}/src/ {toxinidir}/tests/functional
     black --check --diff --color .
     isort --check --diff --color .


### PR DESCRIPTION
This feature is meant for supporting Juju controller HA mode, not to specify multiple standalone controllers.

Closes: https://github.com/canonical/charm-prometheus-juju-exporter/issues/11