### PR TITLE
Add github action for charm release on charmhub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+# This is a template `release.yaml` file for ops charms
+# This file is managed by bootstack-charms-spec and should not be modified
+# within individual charm repos. https://launchpad.net/bootstack-charms-spec
+
+name: Release to Edge
+
+on:
+  push:
+    branches: [ master, main ]
+
+jobs:
+  release:
+    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@main
+    secrets: inherit
+    with:
+      python-version-unit: "['3.8', '3.10']"
+      python-version-func: "3.10"
+      tox-version: "<4"
+      channel: "latest/edge"
+      upload-image: false
+      commands: "['make functional']"


### PR DESCRIPTION
The action builds and releases the charm to `edge` channel on [charmhub](https://charmhub.io/prometheus-juju-exporter) when the main branch is updated.