### PR TITLE
Enable nested containers on charm release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ jobs:
       python-version-unit: "['3.8', '3.10']"
       python-version-func: "3.10"
       tox-version: "<4"
+      provider: lxd
+      nested-containers: true
       channel: "latest/edge"
       upload-image: false
       commands: "['make functional']"


### PR DESCRIPTION
Enable nested containers before running functional tests prior to the charm release. 