### PR TITLE
Automatically set snap channel upon install based on the controller version

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -160,19 +160,16 @@ class PrometheusJujuExporterCharm(CharmBase):
         """
         controller_version = self.get_controller_version()
 
-        if controller_version < version.parse("2.6"):
-            raise ControllerIncompatibleError(
-                f"Juju controller version {str(controller_version)} is too old "
-                + "and not supported. Please consider make an upgrade.",
-            )
+        if controller_version.major == 2:
+            if controller_version.minor in [6, 7, 8]:
+                return "2.8/stable"
+            if controller_version.minor == 9:
+                return "2.9/stable"
 
-        if controller_version >= version.parse("3.0"):
-            raise ControllerIncompatibleError("Juju controller 3.x is not yet supported")
-
-        if controller_version < version.parse("2.9"):
-            return "2.8/stable"
-
-        return "2.9/stable"
+        raise ControllerIncompatibleError(
+            f"Juju controller version {str(controller_version)} is not supported. "
+            + "Current supported versions are: 2.6, 2.7, 2.8, 2.9",
+        )
 
     def get_controller_version(self) -> version.Version:
         """Return the version of the current controller."""

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -119,7 +119,9 @@ class ExporterSnap:
         """Return name of the exporter's systemd service."""
         return f"snap.{self.SNAP_NAME}.{self.SNAP_NAME}.service"
 
-    def install(self, snap_path: Optional[str] = None) -> None:
+    def install(
+        self, snap_path: Optional[str] = None, snap_channel: str = "latest/stable"
+    ) -> None:
         """Install prometheus-juju-exporter snap.
 
         This method tries to install snap from local file if parameter :snap_path is provided.
@@ -134,7 +136,7 @@ class ExporterSnap:
             snap.snap_install(snap_path, "--dangerous")
         else:
             logger.info("Installing %s snap from snap store.", self.SNAP_NAME)
-            snap.snap_install(self.SNAP_NAME)
+            snap.snap_install(self.SNAP_NAME, "--channel", snap_channel)
 
     def uninstall(self) -> None:
         """Remove prometheus-juju-exporter snap."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -74,7 +74,6 @@ def test_snap_path_property(resource_exists, resource_size, is_path_expected, ha
         ("2.7.6", "2.8/stable"),  # In case controller version is 2.7.x, return 2.8/stable
         ("2.8.8", "2.8/stable"),  # In case controller version is 2.8.x, return 2.8/stable
         ("2.9.42.2", "2.9/stable"),  # In case controller version is 2.9.x, return 2.9/stable
-        ("3.0.1", "latest/stable"),  # Otherwise, return latest/stable
     ],
 )
 def test_snap_channel_property(controller_version, channel, harness, mocker):
@@ -84,6 +83,23 @@ def test_snap_channel_property(controller_version, channel, harness, mocker):
     )
 
     assert harness.charm.snap_channel == channel
+
+
+@pytest.mark.parametrize(
+    "controller_version",
+    [
+        "2.5.5",  # Controller version too low
+        "3.0.1",  # Controller version too high
+    ],
+)
+def test_snap_channel_property_incompatible_controller(controller_version, harness, mocker):
+    """Test that 'snap_channel' property raises exception for incompatible controller version."""
+    mocker.patch.object(
+        harness.charm, "get_controller_version", return_value=version.parse(controller_version)
+    )
+
+    with pytest.raises(charm.ControllerIncompatibleError):
+        harness.charm.snap_channel
 
 
 def test_get_controller_version_success(harness, mocker):

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -29,12 +29,12 @@ def test_exporter_snap_install(local_snap, mocker):
 
     exporter_ = exporter.ExporterSnap()
 
-    exporter_.install(snap_path)
+    exporter_.install(snap_path, "2.9/stable")
 
     if local_snap:
         mock_snap_install.assert_called_once_with(snap_path, "--dangerous")
     else:
-        mock_snap_install.assert_called_once_with(exporter_.SNAP_NAME)
+        mock_snap_install.assert_called_once_with(exporter_.SNAP_NAME, "--channel", "2.9/stable")
 
 
 def test_exporter_snap_uninstall(mocker):


### PR DESCRIPTION
The prometheus-juju-exporter snap now has versioned tracks facilitating different controller versions. To ease the deployment effort, this PR implements an automatic snap channel selection method to be called upon charm installation. It parses controller version from charm's `agent.conf` file and choose the correct channel for snap accordingly. 

relates-to: https://github.com/canonical/prometheus-juju-exporter/issues/51