### PR TITLE
Add Juju 3.4 support

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,6 +10,10 @@ on:
       - '**.md'
       - '**.rst'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2
@@ -19,7 +23,6 @@ jobs:
         python-version: ['3.8', '3.10']
     with:
       python-version: ${{ matrix.python-version }}
-      tox-version: '<4'
 
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
@@ -29,16 +32,15 @@ jobs:
       matrix:
         include:
           - juju-channel: '2.9/stable'
-            command: 'make functional'
-          - juju-channel: '3.3/stable'
-            command: 'make functional33-jammy'
-          - juju-channel: '3.3/stable'
-            command: 'make functional33-focal'
+            command: 'FUNC_ARGS="--keep-faulty-model juju_29"make functional'
+          - juju-channel: '3.4/stable'
+            command: 'TEST_JUJU3=1 FUNC_ARGS="--keep-faulty-model -b jammy" make functional'
+          - juju-channel: '3.4/stable'
+            command: 'TEST_JUJU3=1 FUNC_ARGS="--keep-faulty-model -b focal" make functional'
     with:
-      command: ${{ matrix.command }}
+      command: TEST_JUJU_CHANNEL=${{ matrix.juju-channel }} ${{ matrix.command }}
       juju-channel: ${{ matrix.juju-channel }}
       nested-containers: true
       provider: 'lxd'
       python-version: '3.10'
       timeout-minutes: 120
-      tox-version: '<4'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           - juju-channel: '2.9/stable'
-            command: 'FUNC_ARGS="--keep-faulty-model juju_29"make functional'
+            command: 'FUNC_ARGS="--keep-faulty-model" make functional'
           - juju-channel: '3.4/stable'
             command: 'TEST_JUJU3=1 FUNC_ARGS="--keep-faulty-model -b jammy" make functional'
           - juju-channel: '3.4/stable'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -32,11 +32,10 @@ jobs:
       matrix:
         include:
           - juju-channel: '2.9/stable'
-            command: 'FUNC_ARGS="--keep-faulty-model" make functional'
+            command: 'make functional'
           - juju-channel: '3.4/stable'
-            command: 'TEST_JUJU3=1 FUNC_ARGS="--keep-faulty-model -b jammy" make functional'
-          - juju-channel: '3.4/stable'
-            command: 'TEST_JUJU3=1 FUNC_ARGS="--keep-faulty-model -b focal" make functional'
+            command: 'TEST_JUJU3=1 make functional'
+
     with:
       command: TEST_JUJU_CHANNEL=${{ matrix.juju-channel }} ${{ matrix.command }}
       juju-channel: ${{ matrix.juju-channel }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -30,11 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - juju-channel: '2.9/stable'
-            command: 'make functional'
-          - juju-channel: '3.4/stable'
-            command: 'TEST_JUJU3=1 make functional'
+        juju-channel: ['3.1/stable', '3.2/stable', '3.3/stable', '3.4/stable']
+        command: ['TEST_JUJU3=1 make functional']
 
     with:
       command: TEST_JUJU_CHANNEL=${{ matrix.juju-channel }} ${{ matrix.command }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ['3.1/stable', '3.2/stable', '3.3/stable', '3.4/stable']
+        juju-channel: ['3.4/stable']
         command: ['TEST_JUJU3=1 make functional']
 
     with:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ unittests:
 	@echo "Running unit tests"
 	@tox -e unit -- ${UNIT_ARGS}
 
-functional:
+functional: build
 	@echo "Executing functional tests using built charm at ${PROJECTPATH}"
 	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ help:
 	@echo " make reformat - run lint tools to auto format code"
 	@echo " make unittests - run the tests defined in the unittest subdirectory"
 	@echo " make functional - run the tests defined in the functional subdirectory"
-	@echo " make functional33 - run the tests defined in the functional subdirectory with juju 3.3 requirements"
 	@echo " make test - run lint, unittests and functional targets"
 	@echo ""
 
@@ -73,17 +72,9 @@ unittests:
 	@echo "Running unit tests"
 	@tox -e unit -- ${UNIT_ARGS}
 
-functional: build
+functional:
 	@echo "Executing functional tests using built charm at ${PROJECTPATH}"
 	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
-
-functional33-jammy: build
-	@echo "Executing functional tests using built charm at ${PROJECTPATH} with juju 3.3 requirements"
-	@CHARM_LOCATION=${PROJECTPATH} tox -e func33-jammy -- ${FUNC_ARGS}
-
-functional33-focal: build
-	@echo "Executing functional tests using built charm at ${PROJECTPATH} with juju 3.3 requirements"
-	@CHARM_LOCATION=${PROJECTPATH} tox -e func33-focal -- ${FUNC_ARGS}
 
 test: lint unittests functional
 	@echo "Tests completed for charm ${CHARM_NAME}."

--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -3,6 +3,10 @@ applications:
     charm: ch:ubuntu
     num_units: 1
 
+  prometheus-juju-exporter:
+    charm: prometheus-juju-exporter
+    num_units: 0
+
   juju-local:
     charm: bootstack-charmers-juju-local
     num_units: 0
@@ -12,5 +16,9 @@ applications:
     num_units: 1
 
 relations:
-  - - "ubuntu"
-    - "juju-local"
+  - - ubuntu
+    - juju-local
+  - - ubuntu
+    - prometheus-juju-exporter
+  - - prometheus
+    - prometheus-juju-exporter

--- a/tests/functional/tests/bundles/bionic.yaml
+++ b/tests/functional/tests/bundles/bionic.yaml
@@ -1,1 +1,0 @@
-base.yaml

--- a/tests/functional/tests/bundles/overlays/bionic.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/bionic.yaml.j2
@@ -1,2 +1,0 @@
-series: bionic
-

--- a/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -5,9 +5,3 @@ applications:
   juju-local:
     options:
       juju-channel: {{ TEST_JUJU_CHANNEL }}
-
-relations:
-  - - "ubuntu"
-    - {{ charm_name }}
-  - - "prometheus"
-    - {{ charm_name }}

--- a/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,7 +1,6 @@
 applications:
   {{ charm_name }}:
     charm: "{{ CHARM_LOCATION }}/{{ charm_name }}.charm"
-    num_units: 0
   juju-local:
     options:
       juju-channel: {{ TEST_JUJU_CHANNEL }}

--- a/tests/functional/tests/test_charm.py
+++ b/tests/functional/tests/test_charm.py
@@ -115,7 +115,7 @@ class BasicPrometheusJujuExporterTests(unittest.TestCase):
 
     @tenacity.retry(
         wait=tenacity.wait_fixed(5),
-        stop=tenacity.stop_after_attempt(12),
+        stop=tenacity.stop_after_attempt(24),
     )
     def validate_exporter(self, expected_machine_count: int = 1) -> None:
         """Verify that exporter exposes expected data on '/metrics' endpoint.

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -3,7 +3,6 @@ charm_name: prometheus-juju-exporter
 gate_bundles:
   - jammy
   - focal
-  - bionic
 
 tests:
   - tests.test_charm.BasicPrometheusJujuExporterTests

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ passenv =
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
   OS_*
+  TEST_*
 
 [testenv:dev-environment]
 envdir = {toxinidir}/.venv
@@ -77,36 +78,8 @@ deps =
     pytest-cov
 
 [testenv:func]
-setenv =
-  TEST_JUJU_CHANNEL = 2.9/stable
 changedir = {toxinidir}/tests/functional
-commands = functest-run-suite
+commands = functest-run-suite {posargs:--keep-faulty-model}
 deps =
-  git+https://github.com/openstack-charmers/zaza.git#egg=zaza
-  -r {toxinidir}/tests/functional/requirements.txt
-
-[testenv:func33-jammy]
-setenv =
-  TEST_JUJU_CHANNEL = 3.3/stable
-changedir = {toxinidir}/tests/functional
-commands =
-  # NOTE(mertkirpici): functest-run-suite -b jammy focal
-  # or functest-run-suite -b jammy -b focal does not work
-  # https://github.com/openstack-charmers/zaza/issues/614
-  functest-run-suite -b jammy
-deps =
-  git+https://github.com/openstack-charmers/zaza.git@libjuju-3.1#egg=zaza[juju-33]
-  -r {toxinidir}/tests/functional/requirements.txt
-
-[testenv:func33-focal]
-setenv =
-  TEST_JUJU_CHANNEL = 3.3/stable
-changedir = {toxinidir}/tests/functional
-commands =
-  # NOTE(mertkirpici): functest-run-suite -b jammy focal
-  # or functest-run-suite -b jammy -b focal does not work
-  # https://github.com/openstack-charmers/zaza/issues/614
-  functest-run-suite -b focal
-deps =
-  git+https://github.com/openstack-charmers/zaza.git@libjuju-3.1#egg=zaza[juju-33]
+  git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
   -r {toxinidir}/tests/functional/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -81,5 +81,5 @@ deps =
 changedir = {toxinidir}/tests/functional
 commands = functest-run-suite {posargs:--keep-faulty-model}
 deps =
-  git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
+  git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
   -r {toxinidir}/tests/functional/requirements.txt


### PR DESCRIPTION
Drop unnecessary tox env and Makefile targets and switch from Juju 3.3. to Juju 3.4

Add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.

~~Blocked until [#655](https://github.com/openstack-charmers/zaza/pull/655) is merged.~~