### PR TITLE
Rely on the 3/{risk} snap channel for any 3.x controller

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -175,7 +175,7 @@ class PrometheusJujuExporterCharm(CharmBase):
                 return "2.9/stable"
         elif controller_version.major == 3:
             if controller_version.minor in range(1, 6):
-                return f"3/stable"
+                return "3/stable"
 
         raise ControllerIncompatibleError(
             f"Juju controller version {str(controller_version)} is not supported. "

--- a/src/charm.py
+++ b/src/charm.py
@@ -174,8 +174,8 @@ class PrometheusJujuExporterCharm(CharmBase):
             if controller_version.minor == 9:
                 return "2.9/stable"
         elif controller_version.major == 3:
-            if controller_version.minor in [1, 2, 3, 4, 5]:
-                return f"3.{controller_version.minor}/stable"
+            if controller_version.minor in range(1, 6):
+                return f"3/stable"
 
         raise ControllerIncompatibleError(
             f"Juju controller version {str(controller_version)} is not supported. "

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -74,10 +74,10 @@ def test_snap_path_property(resource_exists, resource_size, is_path_expected, ha
         ("2.7.6", "2.8/stable"),  # In case controller version is 2.7.x, return 2.8/stable
         ("2.8.8", "2.8/stable"),  # In case controller version is 2.8.x, return 2.8/stable
         ("2.9.42.2", "2.9/stable"),  # In case controller version is 2.9.x, return 2.9/stable
-        ("3.1.5", "3.1/stable"),  # In case controller version is 3.1.5, return 3.1/stable
-        ("3.2.5", "3.2/stable"),  # In case controller version is 3.2.5, return 3.2/stable
-        ("3.3.4", "3.3/stable"),  # In case controller version is 3.3.4, return 3.3/stable
-        ("3.4.1", "3.4/stable"),  # In case controller version is 3.4.1, return 3.4/stable
+        ("3.1.5", "3/stable"),  # In case controller version is 3.1.5, return 3/stable
+        ("3.2.5", "3/stable"),  # In case controller version is 3.2.5, return 3/stable
+        ("3.3.4", "3/stable"),  # In case controller version is 3.3.4, return 3/stable
+        ("3.4.1", "3/stable"),  # In case controller version is 3.4.1, return 3/stable
     ],
 )
 def test_snap_channel_property(controller_version, channel, harness, mocker):


### PR DESCRIPTION
We have decided to close all 3.y/{risk} snap channels since a single
version should suffice for all 3.x controllers. We therefore need to
also update the snap channel selection mechanism here.

Fixes: #54
