### PR TITLE
Ensure prometheus_interface is included in build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # prometheus_interface library is a submodule
-          submodules: recursive
+          submodules: true
       - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
         uses: canonical/setup-lxd@v0.1.1
       - name: Upload charm to charmhub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # prometheus_interface library is a submodule
+          submodules: recursive
       - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
         uses: canonical/setup-lxd@v0.1.1
       - name: Upload charm to charmhub

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean:
 	@echo "Cleaning charmcraft"
 	@charmcraft clean
 
-build: clean
+build: clean submodules
 	@echo "Building charm"
 	@charmcraft -v pack ${BUILD_ARGS}
 	@bash -c ./rename.sh

--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ make build
 ### Step 1 - Clone and build the charm
 Clone this repository (if you haven't already) and run `make build`.
 
+NOTE: this repository includes submodules.
+It is important that these are checked out before building the charm.
+The `build` make target will init and update the submodules as a dependency,
+or you can manually run `make submodules` or use the `git submodule` commands directly.
+
 ```bash
 git clone https://github.com/canonical/charm-prometheus-juju-exporter.git
 cd charm-prometheus-juju-exporter/
-git submodule init
-git submodule update
 make build
 ```
 ### Step 2 - Deploy charm with snap as a resource


### PR DESCRIPTION
prometheus_interface library is a git submodule,
so we must update git submodules after checking out the repo
for building the charm.

Ref. #47