### PR TITLE
Partially revert #52

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -32,6 +32,10 @@ jobs:
       matrix:
         juju-channel: ['3.4/stable', '3.5/stable']
         command: ['TEST_JUJU3=1 make functional']
+        include:
+          - juju-channel: '2.9/stable'
+            command: 'make functional'
+
 
     with:
       command: TEST_JUJU_CHANNEL=${{ matrix.juju-channel }} ${{ matrix.command }}

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,3 +1,3 @@
 python-openstackclient
-# https://github.com/juju/python-libjuju/issues/1184
+# https://github.com/juju/python-libjuju/issues/1184 is not backport to older libjuju release (e.g juju 2.x)
 websockets<14.0

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,1 +1,3 @@
 python-openstackclient
+# https://github.com/juju/python-libjuju/issues/1184
+websockets<14.0

--- a/tests/functional/tests/bundles/bionic.yaml
+++ b/tests/functional/tests/bundles/bionic.yaml
@@ -1,0 +1,1 @@
+base.yaml

--- a/tests/functional/tests/bundles/overlays/bionic.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/bionic.yaml.j2
@@ -1,0 +1,2 @@
+series: bionic
+


### PR DESCRIPTION
- Add back functional test for bionic and juju 2.9 which is remove in #52 
- Add pin to workaround https://github.com/juju/python-libjuju/issues/1184 in older libjuju release (e.g. 2.x)

closes: #67