### PR TITLE
Add bionic into functional test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 charmhelpers
-packaging
+packaging < 22.0 # make sure this works on all ubuntu@18.04, ubuntu@20.04, and ubuntu@22.04,
 # pin ops framework version to
 # support bionic deployments
 ops >= 1.5.0,< 2.0.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -192,7 +192,7 @@ class PrometheusJujuExporterCharm(CharmBase):
         if not controller_version:
             raise RuntimeError("Charm failed to fetch controller's version.")
 
-        return version.parse(controller_version)
+        return version.Version(controller_version)
 
     def get_controller_ca_cert(self) -> str:
         """Get CA certificate used by targeted Juju controller.

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -56,7 +56,7 @@ class ExporterConfig(NamedTuple):
         endpoints: Union[str, List[str]] = self.controller.split(",")
         current_version = ExporterSnap.version()
 
-        if current_version <= version.parse("1.0.1"):
+        if current_version <= version.Version("1.0.1"):
             if len(endpoints) > 1:
                 raise ExporterConfigError(
                     f"Currently installed version of exporter ({current_version}) does "
@@ -231,7 +231,7 @@ class ExporterSnap:
             raise ExporterSnapError("Exporter snap is not installed.")
 
         snap_version = snap_info["installed"].split()[0]
-        return version.parse(snap_version)
+        return version.Version(snap_version)
 
     def restart(self) -> None:
         """Restart exporter service."""

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -3,6 +3,7 @@ charm_name: prometheus-juju-exporter
 gate_bundles:
   - jammy
   - focal
+  - bionic
 
 tests:
   - tests.test_charm.BasicPrometheusJujuExporterTests

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ passenv =
   TEST_*
 
 [testenv:dev-environment]
-envdir = {toxinidir}/.venv
 deps =
   pre-commit
   {[testenv:lint]deps}
@@ -36,7 +35,6 @@ deps =
   {[testenv:func]deps}
 
 [testenv:pre-commit]
-envdir = {[testenv:dev-environment]envdir}
 deps = {[testenv:dev-environment]deps}  # ensure that dev-environment is installed
 commands = pre-commit run --all-files
 
@@ -62,7 +60,6 @@ deps =
     {[testenv:func]deps}
 
 [testenv:reformat]
-envdir = {toxworkdir}/lint
 commands =
     black .
     isort .


### PR DESCRIPTION
This is an regresion of #68 

- Add bionic into gate bundle
- Make sure the charm supports bionic
- Remove `envdir` from `tox.ini` as that's an unexpected usage of `envdir` and is removed in `tox >= 4`