### PR TITLE
Add support for Juju 3.6

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         runs-on: [[ubuntu-22.04]]
         test-command: ['tox -e func']
-        juju-channel: ["2.9/stable", "3.4/stable", "3.5/stable"]
+        juju-channel: ["2.9/stable", "3.4/stable", "3.5/stable", "3.6/stable"]
     steps:
 
       - uses: actions/checkout@v4

--- a/src/charm.py
+++ b/src/charm.py
@@ -174,12 +174,11 @@ class PrometheusJujuExporterCharm(CharmBase):
             if controller_version.minor == 9:
                 return "2.9/stable"
         elif controller_version.major == 3:
-            if controller_version.minor in range(1, 6):
-                return "3/stable"
+            return "3/stable"
 
         raise ControllerIncompatibleError(
             f"Juju controller version {str(controller_version)} is not supported. "
-            + "Current supported versions are: 2.6, 2.7, 2.8, 2.9, 3.1, 3.2, 3.3, 3.4, 3.5",
+            + "Current supported versions are: 2.6 to 2.9, and 3.x",
         )
 
     def get_controller_version(self) -> version.Version:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -78,6 +78,7 @@ def test_snap_path_property(resource_exists, resource_size, is_path_expected, ha
         ("3.2.5", "3/stable"),  # In case controller version is 3.2.5, return 3/stable
         ("3.3.4", "3/stable"),  # In case controller version is 3.3.4, return 3/stable
         ("3.4.1", "3/stable"),  # In case controller version is 3.4.1, return 3/stable
+        ("3.6.0", "3/stable"),  # In case controller version is 3.6.0, return 3/stable
     ],
 )
 def test_snap_channel_property(controller_version, channel, harness, mocker):
@@ -93,7 +94,7 @@ def test_snap_channel_property(controller_version, channel, harness, mocker):
     "controller_version",
     [
         "2.5.5",  # Controller version too low
-        "3.0.1",  # Controller version too high
+        "4.0.1",  # Controller version too high
     ],
 )
 def test_snap_channel_property_incompatible_controller(controller_version, harness, mocker):


### PR DESCRIPTION
This commit removes the minor version check for Juju 3.x controllers and
adds specific tests for Juju 3.6.

Fixes: #73
